### PR TITLE
상품 관리 페이지 컴포넌트 리팩토링 및 상태 기반 모달 로직 개선

### DIFF
--- a/apps/web/app/manage/store/products/page.tsx
+++ b/apps/web/app/manage/store/products/page.tsx
@@ -1,267 +1,57 @@
 'use client';
 
-import { useState, useEffect } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
-import { Button, LinkButton, Modal } from '@groble/ui';
-import { PlusIcon } from '@radix-ui/react-icons';
 import { Suspense } from 'react';
+import { LinkButton } from '@groble/ui';
+import { PlusIcon } from '@radix-ui/react-icons';
 
-import ProductCard from '@/entities/product/ui/product-card';
 import LoadingSpinner from '@/shared/ui/LoadingSpinner';
-
-import {
-  useSellingContents,
-  useDeleteContent,
-  useActivateContent,
-} from '@/features/manage/hooks/useSellingContents';
-import { showToast } from '@/shared/ui/Toast';
-import type {
-  ContentStatus,
-  ContentPreviewCardResponse,
-} from '@/features/manage/types/productTypes';
 import MobileStoreHeader from '@/features/manage/store/ui/MobileStoreHeader';
 import MobileFloatingButton from '@/shared/ui/MobileFloatingButton';
-import MobileLoadMorePagination from '@/shared/ui/MobileLoadMorePagination';
-import NoContent from '@/shared/ui/NoContent';
+
+import { useProductsPageLogic } from '@/features/manage/hooks/useProductsPageLogic';
+import ProductsGrid from '@/features/manage/components/ProductsGrid';
+import ProductsPageModals from '@/features/manage/components/ProductsPageModals';
+import type { ContentStatus } from '@/features/manage/types/productTypes';
 
 function ProductsPageContent() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
+  const {
+    // 상태
+    activeTab,
+    urlPage,
+    items,
+    pageInfo,
+    isLoading,
+    isError,
+    accumulatedItems,
+    isLoadingMore,
 
-  // URL에서 현재 탭과 페이지 정보 가져오기 (데스크톱용)
-  const activeTab = (searchParams.get('tab') as ContentStatus) || 'ACTIVE';
-  const urlPage = parseInt(searchParams.get('page') || '1', 10); // UI는 1부터 시작
-  const currentPage = urlPage - 1; // 서버는 0부터 시작하므로 -1
+    // 모달 상태
+    editModal,
+    setEditModal,
+    deleteModal,
+    setDeleteModal,
+    stopModal,
+    setStopModal,
+    cannotDeleteModal,
+    setCannotDeleteModal,
+    cannotSaleModal,
+    setCannotSaleModal,
 
-  // 모바일용 상태 관리
-  const [mobileCurrentPage, setMobileCurrentPage] = useState(0);
-  const [accumulatedItems, setAccumulatedItems] = useState<
-    ContentPreviewCardResponse[]
-  >([]);
-  const [isLoadingMore, setIsLoadingMore] = useState(false);
-
-  const { items, pageInfo, isLoading, isError } = useSellingContents({
-    state: activeTab,
-    page: currentPage,
-  });
-
-  const deleteContentMutation = useDeleteContent();
-  const activateContentMutation = useActivateContent();
-
-  // 데스크톱에서 첫 로드 또는 탭 변경 시 모바일 누적 데이터 초기화
-  useEffect(() => {
-    if (items.length > 0) {
-      setAccumulatedItems(items);
-      setMobileCurrentPage(0);
-    }
-  }, [items, activeTab]);
-
-  // 모바일 더보기 핸들러
-  const handleLoadMore = async () => {
-    if (isLoadingMore || !pageInfo || pageInfo.last) return;
-
-    setIsLoadingMore(true);
-
-    try {
-      // 다음 페이지 데이터를 가져오기 위해 mobileCurrentPage + 1 사용
-      const nextPage = mobileCurrentPage + 1;
-      const { getSellingContents } = await import(
-        '@/features/manage/api/productApi'
-      );
-
-      const response = await getSellingContents({
-        state: activeTab,
-        page: nextPage,
-        size: 12,
-        sort: 'createdAt',
-      });
-
-      if (response.data) {
-        setAccumulatedItems((prev) => [...prev, ...response.data.items]);
-        setMobileCurrentPage(nextPage);
-      }
-    } catch (error) {
-      showToast.error('더 많은 콘텐츠를 불러오는데 실패했습니다.');
-    } finally {
-      setIsLoadingMore(false);
-    }
-  };
-
-  // 모달 상태 관리
-  const [editModal, setEditModal] = useState<{
-    isOpen: boolean;
-    contentId: number | null;
-  }>({
-    isOpen: false,
-    contentId: null,
-  });
-  const [deleteModal, setDeleteModal] = useState<{
-    isOpen: boolean;
-    contentId: number | null;
-  }>({
-    isOpen: false,
-    contentId: null,
-  });
-
-  // 탭 변경 핸들러
-  const handleTabChange = (tab: ContentStatus) => {
-    const params = new URLSearchParams(searchParams.toString());
-    params.set('tab', tab);
-    params.set('page', '1'); // 탭 변경 시 첫 페이지로 (UI 기준)
-    router.push(`?${params.toString()}`);
-
-    // 모바일 상태 초기화
-    setMobileCurrentPage(0);
-    setAccumulatedItems([]);
-  };
-
-  // 콘텐츠 판매 활성화 핸들러
-  const handleActivateContent = async (contentId: number) => {
-    try {
-      await activateContentMutation.mutateAsync(contentId);
-      showToast.success('콘텐츠가 판매 활성화되었습니다.');
-    } catch (error) {
-      showToast.error('콘텐츠 판매 활성화에 실패했습니다.');
-    }
-  };
-
-  // 콘텐츠 삭제 핸들러
-  const handleDeleteContent = async (contentId: number) => {
-    try {
-      await deleteContentMutation.mutateAsync(contentId);
-      showToast.success('콘텐츠가 삭제되었습니다.');
-      setDeleteModal({ isOpen: false, contentId: null });
-    } catch (error) {
-      showToast.error('콘텐츠 삭제에 실패했습니다.');
-    }
-  };
-
-  // 콘텐츠 수정 핸들러
-  const handleEditContent = (contentId: number) => {
-    router.push(`/products/register/info?contentId=${contentId}`);
-    setEditModal({ isOpen: false, contentId: null });
-  };
-
-  // 판매 관리 핸들러
-  const handleManageContent = (contentId: number) => {
-    router.push(`/manage/store/products/${contentId}`);
-  };
-
-  // 통계 보기 핸들러
-  const handleViewStats = (contentId: number) => {
-    router.push(`/manage/store/products/${contentId}/sales`);
-  };
-
-  // 수정하기 모달 열기
-  const openEditModal = (contentId: number) => {
-    setEditModal({ isOpen: true, contentId });
-  };
-
-  // 삭제하기 모달 열기
-  const openDeleteModal = (contentId: number) => {
-    setDeleteModal({ isOpen: true, contentId });
-  };
-
-  // 드롭다운 아이템 생성 함수
-  const getDropdownItems = (content: ContentPreviewCardResponse) => {
-    const items = [];
-
-    // 판매중단이 아닌 경우에만 수정하기 포함
-    if (content.status !== 'DISCONTINUED') {
-      items.push({
-        label: '수정하기',
-        onClick: () => openEditModal(content.contentId),
-      });
-    }
-
-    // 삭제하기는 항상 포함
-    items.push({
-      label: '삭제하기',
-      onClick: () => openDeleteModal(content.contentId),
-      destructive: true,
-    });
-
-    return items;
-  };
-
-  // 상태별 버튼 렌더링
-  const renderActionButtons = (content: ContentPreviewCardResponse) => {
-    if (content.status === 'ACTIVE') {
-      // 판매중 - 통계보기, 판매관리 버튼
-      return (
-        <div className="mt-3 flex gap-2">
-          {/* <Button
-            onClick={() => handleViewStats(content.contentId)}
-            group="outlined"
-            type="tertiary"
-            size="x-small"
-            className="flex-1"
-          >
-            통계보기
-          </Button> */}
-          <Button
-            onClick={() => handleManageContent(content.contentId)}
-            group="solid"
-            type="secondary"
-            size="x-small"
-            className="flex-1"
-          >
-            판매관리
-          </Button>
-        </div>
-      );
-    } else if (content.status === 'DISCONTINUED') {
-      // 판매중단 - 판매관리 버튼만
-      return (
-        <div className="mt-3 flex gap-2">
-          <Button
-            onClick={() => handleManageContent(content.contentId)}
-            group="solid"
-            type="secondary"
-            size="x-small"
-            className="w-full"
-          >
-            판매관리
-          </Button>
-        </div>
-      );
-    } else if (content.status === 'DRAFT') {
-      // 작성중 - 판매하기, 판매관리 버튼
-      return (
-        <div className="mt-3 flex gap-2">
-          <Button
-            onClick={() => handleActivateContent(content.contentId)}
-            group="outlined"
-            type="tertiary"
-            size="x-small"
-            className="flex-1"
-          >
-            판매하기
-          </Button>
-          <Button
-            onClick={() => handleManageContent(content.contentId)}
-            group="solid"
-            type="secondary"
-            size="x-small"
-            className="flex-1"
-          >
-            판매관리
-          </Button>
-        </div>
-      );
-    } else {
-      // 다른 상태 (심사중, 심사완료 등)
-      return (
-        <div className="mt-3">
-          <div className="text-sm text-gray-500 text-center py-2">
-            {content.status === 'PENDING' && '심사중'}
-            {content.status === 'VALIDATED' && '심사완료(승인)'}
-            {content.status === 'REJECTED' && '심사완료(거절)'}
-          </div>
-        </div>
-      );
-    }
-  };
+    // 핸들러들
+    handleTabChange,
+    handleLoadMore,
+    handleActivateContent,
+    handleDeleteContent,
+    handleStopContent,
+    handleEditContent,
+    handleManageContent,
+    handleViewStats,
+    openEditModal,
+    openDeleteModal,
+    openStopModal,
+    openCannotDeleteModal,
+    openCannotSaleModal,
+  } = useProductsPageLogic();
 
   if (isLoading) {
     return (
@@ -285,6 +75,7 @@ function ProductsPageContent() {
     <div className="md:pt-0  md:pb-0">
       {/* 모바일 헤더 - md 미만에서만 표시 */}
       <MobileStoreHeader title="상품 관리" />
+
       <div className="min-h-[calc(100vh-122px)] mt-16 bg-white px-5 md:px-9 py-5 md:py-12 md:rounded-xl md:shadow-card">
         <div className="hidden md:flex justify-between items-center mb-8">
           <h1 className="text-heading-1 text-label-normal font-bold">
@@ -320,51 +111,25 @@ function ProductsPageContent() {
           </button>
         </div>
 
-        {/* 콘텐츠 그리드 */}
-        {(accumulatedItems.length > 0 ? accumulatedItems : items).length > 0 ? (
-          <div
-            className="grid grid-cols-1 xs:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6"
-            style={{ gridAutoRows: '1fr' }}
-          >
-            {(accumulatedItems.length > 0 ? accumulatedItems : items).map(
-              (content) => (
-                <div key={content.contentId} className="flex flex-col min-h-0">
-                  <div className="flex-1">
-                    <ProductCard
-                      contentId={content.contentId}
-                      thumbnailUrl={content.thumbnailUrl}
-                      title={content.title}
-                      lowestPrice={content.lowestPrice}
-                      priceOptionLength={content.priceOptionLength}
-                      orderStatus={content.status}
-                      purchasedAt={content.createdAt}
-                      dotDirection="vertical"
-                      dropdownItems={getDropdownItems(content)}
-                    />
-                  </div>
-                  <div className="mt-auto">{renderActionButtons(content)}</div>
-                </div>
-              )
-            )}
-          </div>
-        ) : (
-          <div className="flex flex-col items-center justify-center py-20">
-            <NoContent message="아직 상품이 없어요" />
-          </div>
-        )}
-
-        {/* 페이지네이션 */}
-        {pageInfo && accumulatedItems.length > 0 && (
-          <div className="mt-8 ">
-            <MobileLoadMorePagination
-              currentPage={urlPage} // UI 기준 페이지 번호 (1부터 시작)
-              totalPages={pageInfo.totalPages}
-              hasNextPage={!pageInfo.last}
-              isLoadingMore={isLoadingMore}
-              onLoadMore={handleLoadMore}
-            />
-          </div>
-        )}
+        {/* 상품 그리드 컴포넌트 */}
+        <ProductsGrid
+          items={items}
+          accumulatedItems={accumulatedItems}
+          pageInfo={pageInfo}
+          urlPage={urlPage}
+          isLoadingMore={isLoadingMore}
+          onLoadMore={handleLoadMore}
+          handlers={{
+            openEditModal,
+            openStopModal,
+            openDeleteModal,
+            openCannotDeleteModal,
+            openCannotSaleModal,
+            handleActivateContent,
+            handleManageContent,
+            handleViewStats,
+          }}
+        />
       </div>
 
       {/* 모바일 플로팅 버튼 */}
@@ -372,33 +137,23 @@ function ProductsPageContent() {
         상품등록
       </MobileFloatingButton>
 
-      {/* 수정하기 모달 */}
-      <Modal
-        isOpen={editModal.isOpen}
-        onRequestClose={() => setEditModal({ isOpen: false, contentId: null })}
-        title="정말 수정하시겠습니까?"
-        subText="수정을 시작하면 편집 페이지로 이동됩니다."
-        actionButton="수정하기"
-        secondaryButton="취소"
-        onActionClick={() =>
-          editModal.contentId && handleEditContent(editModal.contentId)
-        }
-      />
-
-      {/* 삭제하기 모달 */}
-      <Modal
-        isOpen={deleteModal.isOpen}
-        onRequestClose={() =>
-          setDeleteModal({ isOpen: false, contentId: null })
-        }
-        title="정말 삭제하시겠습니까?"
-        subText="삭제된 콘텐츠는 복구할 수 없습니다."
-        actionButton="삭제하기"
-        secondaryButton="취소"
-        onActionClick={() =>
-          deleteModal.contentId && handleDeleteContent(deleteModal.contentId)
-        }
-        actionButtonColor="danger"
+      {/* 모달들 컴포넌트 */}
+      <ProductsPageModals
+        editModal={editModal}
+        deleteModal={deleteModal}
+        stopModal={stopModal}
+        cannotDeleteModal={cannotDeleteModal}
+        cannotSaleModal={cannotSaleModal}
+        setEditModal={setEditModal}
+        setDeleteModal={setDeleteModal}
+        setStopModal={setStopModal}
+        setCannotDeleteModal={setCannotDeleteModal}
+        setCannotSaleModal={setCannotSaleModal}
+        handlers={{
+          handleEditContent,
+          handleDeleteContent,
+          handleStopContent,
+        }}
       />
     </div>
   );

--- a/apps/web/entities/product/model/product-types.ts
+++ b/apps/web/entities/product/model/product-types.ts
@@ -32,7 +32,7 @@ export type ProductCardProps = BasicProductCardProps & {
   dotDirection?: 'horizontal' | 'vertical'; // 더보기 아이콘 방향 (기본값 horizontal)
 
   // 상태 관련 데이터 (orderStatus가 있으면 자동 표시)
-  orderStatus?: 'PAID' | 'EXPIRED' | 'CANCELLED' | 'ACTIVE' | 'DRAFT';
+  orderStatus?: 'ACTIVE' | 'DRAFT' | 'DELETED' | 'DISCONTINUED';
   purchasedAt?: string;
   merchantUid?: string; // 주문 고유 ID (구매 관리용 라우팅에 사용)
 

--- a/apps/web/entities/product/ui/product-card.tsx
+++ b/apps/web/entities/product/ui/product-card.tsx
@@ -62,12 +62,8 @@ export default function ProductCard({
         return '판매중';
       case 'DRAFT':
         return '작성중';
-      case 'PAID':
-        return '결제완료';
-      case 'EXPIRED':
-        return '기간만료';
-      case 'CANCELLED':
-        return '결제취소';
+      case 'DELETED':
+        return '삭제됨';
       case 'DISCONTINUED':
         return '판매중단';
       default:
@@ -82,11 +78,7 @@ export default function ProductCard({
         return 'text-primary-sub-1';
       case 'DRAFT':
         return 'text-primary-sub-1';
-      case 'PAID':
-        return 'text-status-success';
-      case 'EXPIRED':
-        return 'text-label-neutral';
-      case 'CANCELLED':
+      case 'DELETED':
         return 'text-status-error';
       case 'DISCONTINUED':
         return 'text-status-error';
@@ -197,7 +189,7 @@ export default function ProductCard({
               </button>
 
               {showDropdown && (
-                <div className="absolute right-0 top-7 z-10 w-48 py-1 bg-white border border-line-normal rounded-lg shadow-lg">
+                <div className="absolute right-0 top-7 z-10 w-[6.6rem] py-1 bg-white border border-line-normal rounded-lg shadow-lg">
                   {dropdownItems.map((item, index) => (
                     <button
                       key={index}
@@ -206,11 +198,7 @@ export default function ProductCard({
                         item.onClick();
                         setShowDropdown(false);
                       }}
-                      className={`w-full px-4 py-2 text-left text-sm hover:bg-gray-50 flex items-center gap-2 ${
-                        item.destructive
-                          ? 'text-status-error'
-                          : 'text-label-normal'
-                      }`}
+                      className={`w-full cursor-pointer px-4 py-2 text-left text-sm hover:bg-gray-50 flex items-center gap-2`}
                     >
                       {item.icon}
                       {item.label}

--- a/apps/web/features/manage/api/productApi.ts
+++ b/apps/web/features/manage/api/productApi.ts
@@ -67,3 +67,19 @@ export async function deleteContent(
 
   return response;
 }
+
+/**
+ * 콘텐츠 판매 중단 API
+ */
+export async function stopProductSale(
+  contentId: number
+): Promise<ApiResponse<void>> {
+  const response = await fetchClient<void>(
+    `/api/v1/sell/content/${contentId}/stop`,
+    {
+      method: 'POST',
+    }
+  );
+
+  return response;
+}

--- a/apps/web/features/manage/components/ProductsGrid.tsx
+++ b/apps/web/features/manage/components/ProductsGrid.tsx
@@ -1,0 +1,99 @@
+import ProductCard from '@/entities/product/ui/product-card';
+import NoContent from '@/shared/ui/NoContent';
+import MobileLoadMorePagination from '@/shared/ui/MobileLoadMorePagination';
+import { getDropdownItems, renderActionButtons } from '../utils/productUtils';
+import type {
+  ContentPreviewCardResponse,
+  ContentStatus,
+} from '../types/productTypes';
+
+interface ProductsGridProps {
+  items: ContentPreviewCardResponse[];
+  accumulatedItems: ContentPreviewCardResponse[];
+  pageInfo: any;
+  urlPage: number;
+  isLoadingMore: boolean;
+  onLoadMore: () => void;
+  handlers: {
+    openEditModal: (contentId: number) => void;
+    openStopModal: (contentId: number) => void;
+    openDeleteModal: (contentId: number) => void;
+    openCannotDeleteModal: (contentId: number) => void;
+    openCannotSaleModal: (contentId: number) => void;
+    handleActivateContent: (contentId: number) => void;
+    handleManageContent: (contentId: number) => void;
+    handleViewStats: (contentId: number) => void;
+  };
+}
+
+export default function ProductsGrid({
+  items,
+  accumulatedItems,
+  pageInfo,
+  urlPage,
+  isLoadingMore,
+  onLoadMore,
+  handlers,
+}: ProductsGridProps) {
+  const displayItems = accumulatedItems.length > 0 ? accumulatedItems : items;
+
+  return (
+    <>
+      {/* 콘텐츠 그리드 */}
+      {displayItems.length > 0 ? (
+        <div
+          className="grid grid-cols-1 xs:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6"
+          style={{ gridAutoRows: '1fr' }}
+        >
+          {displayItems.map((content) => (
+            <div key={content.contentId} className="flex flex-col min-h-0">
+              <div className="flex-1">
+                <ProductCard
+                  contentId={content.contentId}
+                  thumbnailUrl={content.thumbnailUrl}
+                  title={content.title}
+                  lowestPrice={content.lowestPrice ?? undefined}
+                  priceOptionLength={content.priceOptionLength}
+                  orderStatus={content.status as ContentStatus}
+                  purchasedAt={content.createdAt}
+                  dotDirection="vertical"
+                  dropdownItems={getDropdownItems(content, {
+                    openEditModal: handlers.openEditModal,
+                    openStopModal: handlers.openStopModal,
+                    openDeleteModal: handlers.openDeleteModal,
+                    openCannotDeleteModal: handlers.openCannotDeleteModal,
+                  })}
+                />
+              </div>
+              <div className="mt-auto">
+                {renderActionButtons(content, {
+                  handleActivateContent: handlers.handleActivateContent,
+                  handleManageContent: handlers.handleManageContent,
+                  handleViewStats: handlers.handleViewStats,
+                  openCannotSaleModal: handlers.openCannotSaleModal,
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="flex flex-col items-center justify-center py-20">
+          <NoContent message="아직 상품이 없어요" />
+        </div>
+      )}
+
+      {/* 페이지네이션 */}
+      {pageInfo && accumulatedItems.length > 0 && (
+        <div className="mt-8">
+          <MobileLoadMorePagination
+            currentPage={urlPage} // UI 기준 페이지 번호 (1부터 시작)
+            totalPages={pageInfo.totalPages}
+            hasNextPage={!pageInfo.last}
+            isLoadingMore={isLoadingMore}
+            onLoadMore={onLoadMore}
+          />
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/web/features/manage/components/ProductsPageModals.tsx
+++ b/apps/web/features/manage/components/ProductsPageModals.tsx
@@ -1,0 +1,126 @@
+import { Modal } from '@groble/ui';
+
+interface ModalState {
+  isOpen: boolean;
+  contentId: number | null;
+}
+
+interface ProductsPageModalsProps {
+  editModal: ModalState;
+  deleteModal: ModalState;
+  stopModal: ModalState;
+  cannotDeleteModal: ModalState;
+  cannotSaleModal: ModalState;
+  setEditModal: (state: ModalState) => void;
+  setDeleteModal: (state: ModalState) => void;
+  setStopModal: (state: ModalState) => void;
+  setCannotDeleteModal: (state: ModalState) => void;
+  setCannotSaleModal: (state: ModalState) => void;
+  handlers: {
+    handleEditContent: (contentId: number) => void;
+    handleDeleteContent: (contentId: number) => void;
+    handleStopContent: (contentId: number) => void;
+  };
+}
+
+export default function ProductsPageModals({
+  editModal,
+  deleteModal,
+  stopModal,
+  cannotDeleteModal,
+  cannotSaleModal,
+  setEditModal,
+  setDeleteModal,
+  setStopModal,
+  setCannotDeleteModal,
+  setCannotSaleModal,
+  handlers,
+}: ProductsPageModalsProps) {
+  return (
+    <>
+      {/* 수정하기 모달 */}
+      <Modal
+        isOpen={editModal.isOpen}
+        onRequestClose={() => setEditModal({ isOpen: false, contentId: null })}
+        title="정말 수정하시겠습니까?"
+        subText="수정을 시작하면 편집 페이지로 이동됩니다."
+        actionButton="수정하기"
+        secondaryButton="취소"
+        onActionClick={() =>
+          editModal.contentId && handlers.handleEditContent(editModal.contentId)
+        }
+      />
+
+      {/* 삭제하기 모달 */}
+      <Modal
+        isOpen={deleteModal.isOpen}
+        onRequestClose={() =>
+          setDeleteModal({ isOpen: false, contentId: null })
+        }
+        title="정말 삭제하시겠습니까?"
+        subText="삭제된 콘텐츠는 복구할 수 없습니다."
+        actionButton="삭제하기"
+        secondaryButton="취소"
+        onActionClick={() =>
+          deleteModal.contentId &&
+          handlers.handleDeleteContent(deleteModal.contentId)
+        }
+        actionButtonColor="danger"
+      />
+
+      {/* 중단하기 모달 */}
+      <Modal
+        isOpen={stopModal.isOpen}
+        onRequestClose={() => setStopModal({ isOpen: false, contentId: null })}
+        title="판매를 중단할까요?"
+        subText={[
+          '언제든 다시 시작할 수 있어요.',
+          '[작성중]에서 판매하기를 선택해주세요.',
+        ]}
+        actionButton="중단하기"
+        secondaryButton="취소"
+        onActionClick={() =>
+          stopModal.contentId && handlers.handleStopContent(stopModal.contentId)
+        }
+        actionButtonColor="primary"
+      />
+
+      {/* 삭제할 수 없어요 모달 */}
+      <Modal
+        isOpen={cannotDeleteModal.isOpen}
+        onRequestClose={() =>
+          setCannotDeleteModal({ isOpen: false, contentId: null })
+        }
+        title="삭제할 수 없어요"
+        subText={[
+          '판매된 이력이 있는 상품은 삭제할 수 없습니다.',
+          '판매를 멈추려면 [중단하기] 버튼을 눌러주세요.',
+        ]}
+        actionButton="중단하기"
+        secondaryButton="취소"
+        onActionClick={() =>
+          cannotDeleteModal.contentId &&
+          handlers.handleStopContent(cannotDeleteModal.contentId)
+        }
+        actionButtonColor="primary"
+      />
+
+      {/* 아직 판매할 수 없어요 모달 */}
+      <Modal
+        isOpen={cannotSaleModal.isOpen}
+        onRequestClose={() =>
+          setCannotSaleModal({ isOpen: false, contentId: null })
+        }
+        title="아직 판매할 수 없어요"
+        subText="판매를 위해 필요한 내용을 먼저 채워주세요."
+        actionButton="수정하기"
+        secondaryButton="취소"
+        onActionClick={() =>
+          cannotSaleModal.contentId &&
+          handlers.handleEditContent(cannotSaleModal.contentId)
+        }
+        actionButtonColor="primary"
+      />
+    </>
+  );
+}

--- a/apps/web/features/manage/hooks/useProductsPageLogic.ts
+++ b/apps/web/features/manage/hooks/useProductsPageLogic.ts
@@ -1,0 +1,240 @@
+import { useState, useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import {
+  useSellingContents,
+  useDeleteContent,
+  useActivateContent,
+} from './useSellingContents';
+import { stopProductSale, getSellingContents } from '../api/productApi';
+import { showToast } from '@/shared/ui/Toast';
+import type {
+  ContentStatus,
+  ContentPreviewCardResponse,
+} from '../types/productTypes';
+
+export function useProductsPageLogic() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  // URL에서 현재 탭과 페이지 정보 가져오기 (데스크톱용)
+  const activeTab = (searchParams.get('tab') as ContentStatus) || 'ACTIVE';
+  const urlPage = parseInt(searchParams.get('page') || '1', 10); // UI는 1부터 시작
+  const currentPage = urlPage - 1; // 서버는 0부터 시작하므로 -1
+
+  // 모바일용 상태 관리
+  const [mobileCurrentPage, setMobileCurrentPage] = useState(0);
+  const [accumulatedItems, setAccumulatedItems] = useState<
+    ContentPreviewCardResponse[]
+  >([]);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+
+  // API 호출
+  const { items, pageInfo, isLoading, isError } = useSellingContents({
+    state: activeTab,
+    page: currentPage,
+  });
+
+  const deleteContentMutation = useDeleteContent();
+  const activateContentMutation = useActivateContent();
+
+  // 모달 상태 관리
+  const [editModal, setEditModal] = useState<{
+    isOpen: boolean;
+    contentId: number | null;
+  }>({
+    isOpen: false,
+    contentId: null,
+  });
+
+  const [deleteModal, setDeleteModal] = useState<{
+    isOpen: boolean;
+    contentId: number | null;
+  }>({
+    isOpen: false,
+    contentId: null,
+  });
+
+  const [stopModal, setStopModal] = useState<{
+    isOpen: boolean;
+    contentId: number | null;
+  }>({
+    isOpen: false,
+    contentId: null,
+  });
+
+  const [cannotDeleteModal, setCannotDeleteModal] = useState<{
+    isOpen: boolean;
+    contentId: number | null;
+  }>({
+    isOpen: false,
+    contentId: null,
+  });
+
+  const [cannotSaleModal, setCannotSaleModal] = useState<{
+    isOpen: boolean;
+    contentId: number | null;
+  }>({
+    isOpen: false,
+    contentId: null,
+  });
+
+  // 데스크톱에서 첫 로드 또는 탭 변경 시 모바일 누적 데이터 초기화
+  useEffect(() => {
+    if (items.length > 0) {
+      setAccumulatedItems(items);
+      setMobileCurrentPage(0);
+    }
+  }, [items, activeTab]);
+
+  // 탭 변경 핸들러
+  const handleTabChange = (tab: ContentStatus) => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('tab', tab);
+    params.set('page', '1'); // 탭 변경 시 첫 페이지로 (UI 기준)
+    router.push(`?${params.toString()}`);
+
+    // 모바일 상태 초기화
+    setMobileCurrentPage(0);
+    setAccumulatedItems([]);
+  };
+
+  // 모바일 더보기 핸들러
+  const handleLoadMore = async () => {
+    if (isLoadingMore || !pageInfo || pageInfo.last) return;
+
+    setIsLoadingMore(true);
+
+    try {
+      // 다음 페이지 데이터를 가져오기 위해 mobileCurrentPage + 1 사용
+      const nextPage = mobileCurrentPage + 1;
+
+      const response = await getSellingContents({
+        state: activeTab,
+        page: nextPage,
+        size: 12,
+        sort: 'createdAt',
+      });
+
+      if (response.data) {
+        setAccumulatedItems((prev) => [...prev, ...response.data.items]);
+        setMobileCurrentPage(nextPage);
+      }
+    } catch (error) {
+      showToast.error('더 많은 콘텐츠를 불러오는데 실패했습니다.');
+    } finally {
+      setIsLoadingMore(false);
+    }
+  };
+
+  // 콘텐츠 판매 활성화 핸들러
+  const handleActivateContent = async (contentId: number) => {
+    try {
+      await activateContentMutation.mutateAsync(contentId);
+      showToast.success('콘텐츠가 판매 활성화되었습니다.');
+    } catch (error) {
+      showToast.error('콘텐츠 판매 활성화에 실패했습니다.');
+    }
+  };
+
+  // 콘텐츠 삭제 핸들러
+  const handleDeleteContent = async (contentId: number) => {
+    try {
+      await deleteContentMutation.mutateAsync(contentId);
+      showToast.success('콘텐츠가 삭제되었습니다.');
+      setDeleteModal({ isOpen: false, contentId: null });
+    } catch (error) {
+      showToast.error('콘텐츠 삭제에 실패했습니다.');
+    }
+  };
+
+  // 콘텐츠 중단 핸들러
+  const handleStopContent = async (contentId: number) => {
+    try {
+      await stopProductSale(contentId);
+      showToast.success('판매가 중단되었습니다.');
+      setStopModal({ isOpen: false, contentId: null });
+      // 데이터 새로고침을 위해 현재 페이지로 라우팅
+      router.refresh();
+    } catch (error) {
+      showToast.error('판매 중단에 실패했습니다.');
+    }
+  };
+
+  // 콘텐츠 수정 핸들러
+  const handleEditContent = (contentId: number) => {
+    router.push(`/products/register/info?contentId=${contentId}`);
+    setEditModal({ isOpen: false, contentId: null });
+  };
+
+  // 판매 관리 핸들러
+  const handleManageContent = (contentId: number) => {
+    router.push(`/manage/store/products/${contentId}`);
+  };
+
+  // 통계 보기 핸들러
+  const handleViewStats = (contentId: number) => {
+    router.push(`/manage/store/products/${contentId}/sales`);
+  };
+
+  // 모달 열기 함수들
+  const openEditModal = (contentId: number) => {
+    setEditModal({ isOpen: true, contentId });
+  };
+
+  const openDeleteModal = (contentId: number) => {
+    setDeleteModal({ isOpen: true, contentId });
+  };
+
+  const openStopModal = (contentId: number) => {
+    setStopModal({ isOpen: true, contentId });
+  };
+
+  const openCannotDeleteModal = (contentId: number) => {
+    setCannotDeleteModal({ isOpen: true, contentId });
+  };
+
+  const openCannotSaleModal = (contentId: number) => {
+    setCannotSaleModal({ isOpen: true, contentId });
+  };
+
+  return {
+    // 상태
+    activeTab,
+    urlPage,
+    currentPage,
+    mobileCurrentPage,
+    accumulatedItems,
+    isLoadingMore,
+    items,
+    pageInfo,
+    isLoading,
+    isError,
+
+    // 모달 상태
+    editModal,
+    setEditModal,
+    deleteModal,
+    setDeleteModal,
+    stopModal,
+    setStopModal,
+    cannotDeleteModal,
+    setCannotDeleteModal,
+    cannotSaleModal,
+    setCannotSaleModal,
+
+    // 핸들러들
+    handleTabChange,
+    handleLoadMore,
+    handleActivateContent,
+    handleDeleteContent,
+    handleStopContent,
+    handleEditContent,
+    handleManageContent,
+    handleViewStats,
+    openEditModal,
+    openDeleteModal,
+    openStopModal,
+    openCannotDeleteModal,
+    openCannotSaleModal,
+  };
+}

--- a/apps/web/features/manage/types/productTypes.ts
+++ b/apps/web/features/manage/types/productTypes.ts
@@ -17,15 +17,13 @@ export interface ContentPreviewCardResponse {
   priceOptionLength: number;
   /** 콘텐츠 상태 */
   status: ContentStatus;
+  /** 삭제 가능 여부 */
+  isDeletable: boolean;
+  /** 판매 가능 여부 */
+  isAvailableForSale: boolean;
 }
 
-export type ContentStatus =
-  | 'ACTIVE'
-  | 'DRAFT'
-  | 'PENDING'
-  | 'VALIDATED'
-  | 'REJECTED'
-  | 'DISCONTINUED';
+export type ContentStatus = 'ACTIVE' | 'DRAFT' | 'DELETED' | 'DISCONTINUED';
 
 export interface PageInfo {
   /** 현재 페이지 번호 (0부터 시작) */

--- a/apps/web/features/manage/utils/productUtils.tsx
+++ b/apps/web/features/manage/utils/productUtils.tsx
@@ -1,0 +1,149 @@
+import { Button } from '@groble/ui';
+import type { ContentPreviewCardResponse } from '../types/productTypes';
+
+// 드롭다운 아이템 타입 정의
+export interface DropdownItem {
+  label: string;
+  onClick: () => void;
+  destructive?: boolean;
+  icon?: React.ReactNode;
+}
+
+// 드롭다운 아이템 생성 함수
+export function getDropdownItems(
+  content: ContentPreviewCardResponse,
+  handlers: {
+    openEditModal: (contentId: number) => void;
+    openStopModal: (contentId: number) => void;
+    openDeleteModal: (contentId: number) => void;
+    openCannotDeleteModal: (contentId: number) => void;
+  }
+): DropdownItem[] {
+  const items: DropdownItem[] = [];
+
+  // 판매중단이 아닌 경우에만 수정하기 포함
+  if (content.status !== 'DISCONTINUED') {
+    items.push({
+      label: '수정하기',
+      onClick: () => handlers.openEditModal(content.contentId),
+    });
+  }
+
+  // 상태에 따라 중단하기 또는 삭제하기 표시
+  if (content.status === 'ACTIVE') {
+    // 판매중인 경우 중단하기
+    items.push({
+      label: '중단하기',
+      onClick: () => handlers.openStopModal(content.contentId),
+      destructive: true,
+    });
+  } else {
+    // 다른 상태에서는 삭제하기 (isDeletable에 따라 다른 모달)
+    items.push({
+      label: '삭제하기',
+      onClick: () => {
+        if (content.isDeletable) {
+          handlers.openDeleteModal(content.contentId);
+        } else {
+          handlers.openCannotDeleteModal(content.contentId);
+        }
+      },
+      destructive: true,
+    });
+  }
+
+  return items;
+}
+
+// 상태별 버튼 렌더링 함수
+export function renderActionButtons(
+  content: ContentPreviewCardResponse,
+  handlers: {
+    handleActivateContent: (contentId: number) => void;
+    handleManageContent: (contentId: number) => void;
+    handleViewStats: (contentId: number) => void;
+    openCannotSaleModal: (contentId: number) => void;
+  }
+): React.ReactNode {
+  if (content.status === 'ACTIVE') {
+    // 판매중 - 통계보기, 판매관리 버튼
+    return (
+      <div className="mt-3 flex gap-2">
+        {/* <Button
+          onClick={() => handlers.handleViewStats(content.contentId)}
+          group="outlined"
+          type="tertiary"
+          size="x-small"
+          className="flex-1"
+        >
+          통계보기
+        </Button> */}
+        <Button
+          onClick={() => handlers.handleManageContent(content.contentId)}
+          group="solid"
+          type="secondary"
+          size="x-small"
+          className="flex-1"
+        >
+          판매관리
+        </Button>
+      </div>
+    );
+  } else if (content.status === 'DISCONTINUED') {
+    // 판매중단 - 판매관리 버튼만
+    return (
+      <div className="mt-3 flex gap-2">
+        <Button
+          onClick={() => handlers.handleManageContent(content.contentId)}
+          group="solid"
+          type="secondary"
+          size="x-small"
+          className="w-full"
+        >
+          판매관리
+        </Button>
+      </div>
+    );
+  } else if (content.status === 'DRAFT') {
+    // 작성중 - 판매하기, 판매관리 버튼
+    return (
+      <div className="mt-3 flex gap-2">
+        <Button
+          onClick={() => {
+            if (content.isAvailableForSale) {
+              handlers.handleActivateContent(content.contentId);
+            } else {
+              handlers.openCannotSaleModal(content.contentId);
+            }
+          }}
+          group="outlined"
+          type="tertiary"
+          size="x-small"
+          className="flex-1"
+        >
+          판매하기
+        </Button>
+        <Button
+          onClick={() => handlers.handleManageContent(content.contentId)}
+          group="solid"
+          type="secondary"
+          size="x-small"
+          className="flex-1"
+        >
+          판매관리
+        </Button>
+      </div>
+    );
+  } else {
+    // 다른 상태 (심사중, 심사완료 등)
+    return (
+      <div className="mt-3">
+        <div className="text-sm text-gray-500 text-center py-2">
+          {content.status === 'PENDING' && '심사중'}
+          {content.status === 'VALIDATED' && '심사완료(승인)'}
+          {content.status === 'REJECTED' && '심사완료(거절)'}
+        </div>
+      </div>
+    );
+  }
+}

--- a/apps/web/features/profile/model/types.ts
+++ b/apps/web/features/profile/model/types.ts
@@ -15,6 +15,7 @@ export interface UserDetail {
   canSwitchToSeller: boolean;
   sellerAccountNotCreated: boolean;
   verificationStatus?: VerificationStatus;
+  alreadyRegisteredAsSeller: boolean;
 }
 
 import { ComponentType } from 'react';

--- a/apps/web/features/profile/ui/ProfileInfoList.tsx
+++ b/apps/web/features/profile/ui/ProfileInfoList.tsx
@@ -87,7 +87,7 @@ export default function ProfileInfoList({ userData }: ProfileInfoListProps) {
     // BUYER이고 sellerAccountNotCreated가 false인 경우 select-type 페이지로 이동
     if (
       userData?.userType === 'BUYER' &&
-      userData?.sellerAccountNotCreated === false
+      userData?.alreadyRegisteredAsSeller === false
     ) {
       router.push('/users/maker/agree');
       return;

--- a/packages/ui/src/components/Modal.tsx
+++ b/packages/ui/src/components/Modal.tsx
@@ -7,12 +7,14 @@ interface ModalProps {
   isOpen: boolean;
   onRequestClose: () => void;
   title?: string;
-  subText?: string;
+  subText?: string | string[];
   actionButton: string;
   secondaryButton?: string;
   onActionClick: (() => void) | 'close';
   onSecondaryClick?: () => void;
   actionButtonColor?: 'primary' | 'danger';
+  // 줄바꿈 처리 관련 props
+  preserveLineBreaks?: boolean;
   // Textarea 관련 props
   hasTextarea?: boolean;
   textareaValue?: string;
@@ -34,6 +36,7 @@ const Modal: React.FC<ModalProps> = ({
   onActionClick,
   onSecondaryClick,
   actionButtonColor = 'primary',
+  preserveLineBreaks = true,
   hasTextarea = false,
   textareaValue = '',
   onTextareaChange,
@@ -118,9 +121,19 @@ const Modal: React.FC<ModalProps> = ({
             {title}
           </h2>
           {subText && (
-            <p className="text-body-2-normal md:text-headline-1 text-label-neutral leading-7 tracking-[0.009em] whitespace-pre-line">
-              {subText}
-            </p>
+            <div className="text-body-2-normal md:text-headline-1 text-label-neutral  tracking-[0.009em]">
+              {Array.isArray(subText) ? (
+                subText.map((line, index) => (
+                  <p key={index} className="">
+                    {line}
+                  </p>
+                ))
+              ) : (
+                <p className={preserveLineBreaks ? 'whitespace-pre-line' : ''}>
+                  {subText}
+                </p>
+              )}
+            </div>
           )}
         </div>
 


### PR DESCRIPTION
###  주요 변경 사항
- 상품 관리 페이지 컴포넌트 분리 및 구조 개선 (refactor)
- 상품 삭제 및 판매 가능 여부를 나타내는 타입 및 API 확장
- ProductCard에서 상태에 따라 조건부로 모달 호출 가능하도록 개선
- 공통 Modal 컴포넌트에 줄바꿈 지원 기능 추가
- 사용자 프로필 타입 및 관련 로직 개선
- ProductCard 컴포넌트의 타입 호환성 오류 수정

### 기타
- 상품의 상태(삭제 가능/불가능, 판매 가능/불가능)에 따라 다양한 안내 모달을 띄울 수 있도록 확장
- 타입 정의 및 분기 로직 정비를 통해 유지보수성 향상